### PR TITLE
Added check-gluster-status.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased
 
+## [0.0.3] - 2015-10-08
+### Changed
+- Added check-gluster-status.rb
+
 ## [0.0.2] - 2015-07-14
 ### Changed
 - updated sensu-plugin gem to 1.2.0

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 ## Files
  * bin/check-gluster-georepl-status.rb
+ * bin/check-gluster-status.rb
 
 ## Usage
 

--- a/bin/check-gluster-status.rb
+++ b/bin/check-gluster-status.rb
@@ -1,0 +1,65 @@
+#! /usr/bin/env ruby
+#
+#   check-guster-status
+#
+# DESCRIPTION:
+#   Verifies Gluster's volume replication status#
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#   #YELLOW
+#
+# NOTES:
+#
+# LICENSE:
+#   Samuel Terburg <samuel.terburg@panther-it.nl>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-plugin/check/cli'
+
+class GlusterReplStatus < Sensu::Plugin::Check::CLI
+  option :ignore_nfs,
+         short: '-n',
+         long: '--ignore-nfs',
+         description: 'Ignore builtin NFS server',
+         boolean: true,
+         default: false
+
+  option :ignore_selfheal,
+         short: '-s',
+         long: '--ignore-selfheal',
+         description: 'Ignore selfheal service',
+         boolean: true,
+         default: false
+
+  def run
+    errors = []
+    # #YELLOW
+    `sudo gluster volume status`.each_line do |l| # rubocop:disable Style/Next
+      # Don't match those lines or conditions.
+      if l =~ / N /
+        unless (config[:ignore_nfs]      && 'NFS'.include?(l.split[0])) \
+            || (config[:ignore_selfheal] && 'Self-heal'.include?(l.split[0]))
+          errors << "#{l.split[0]} #{l.split[1]} is DOWN"
+        end
+      end
+    end
+
+    if errors.empty?
+      ok
+    else
+      critical errors
+    end
+  end
+end

--- a/bin/check-gluster-status.rb
+++ b/bin/check-gluster-status.rb
@@ -46,13 +46,11 @@ class GlusterReplStatus < Sensu::Plugin::Check::CLI
   def run
     errors = []
     # #YELLOW
-    `sudo gluster volume status`.each_line do |l| # rubocop:disable Style/Next
+    `sudo gluster volume status`.each_line do |l|
       # Don't match those lines or conditions.
-      if l =~ / N /
-        unless (config[:ignore_nfs]      && 'NFS'.include?(l.split[0])) \
-            || (config[:ignore_selfheal] && 'Self-heal'.include?(l.split[0]))
-          errors << "#{l.split[0]} #{l.split[1]} is DOWN"
-        end
+      next unless l =~ / N /
+      unless (config[:ignore_nfs] && 'NFS'.include?(l.split[0])) || (config[:ignore_selfheal] && 'Self-heal'.include?(l.split[0]))
+        errors << "#{l.split[0]} #{l.split[1]} is DOWN"
       end
     end
 

--- a/lib/sensu-plugins-gluster/version.rb
+++ b/lib/sensu-plugins-gluster/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsGluster
   module Version
     MAJOR = 0
     MINOR = 0
-    PATCH = 2
+    PATCH = 3
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
check-gluster-status, will check a normal glusterfs cluster using the "gluster volume status" command.
This differs from the other geo check which will check a georeplicated cluster.
